### PR TITLE
Read configuration from nexus-data

### DIFF
--- a/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
+++ b/src/main/java/com/larscheidschmitzhermes/nexus3/github/oauth/plugin/configuration/GithubOauthConfiguration.java
@@ -55,7 +55,7 @@ public class GithubOauthConfiguration {
         configuration = new Properties();
 
         try {
-            configuration.load(Files.newInputStream(Paths.get(".", "etc", CONFIG_FILE)));
+            configuration.load(Files.newInputStream(Paths.get(System.getenv().getOrDefault("NEXUS_DATA", "."), "etc", CONFIG_FILE)));
         } catch (IOException e) {
             LOGGER.warn("Error reading github oauth properties, falling back to default configuration", e);
         }


### PR DESCRIPTION
While using nexus3 docker image by default etc is owned by root, for container purposes configuration should stay in nexus-data directory.